### PR TITLE
Fix naming of snapshot files to avoid windows woes

### DIFF
--- a/lib/benchfella.ex
+++ b/lib/benchfella.ex
@@ -188,7 +188,7 @@ defmodule Benchfella do
     # FIXME: think about including additional info in the filename, like
     # indication of which tests were run or test settings
     {{year, month, day}, {hour, min, sec}} = :calendar.local_time()
-    :io_lib.format('~B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0B.snapshot',
+    :io_lib.format('~B-~2..0B-~2..0B_~2..0B-~2..0B-~2..0B.snapshot',
                    [year, month, day, hour, min, sec])
   end
 


### PR DESCRIPTION
On windows, files with a : in them (under NTFS) represent an Alternate
Data Steam, but files with two : are invalid.  

The current ```gen_snapshot_name``` generates two : in the filename, this change replaces
them with - and the T with _.