### PR TITLE
Fix Elixir 1.3 warnings

### DIFF
--- a/lib/mix/tasks/bench.ex
+++ b/lib/mix/tasks/bench.ex
@@ -85,7 +85,10 @@ defmodule Mix.Tasks.Bench do
     # Set up the target project's paths
     Mix.Project.get!
     args = ["--no-start"]
-    if no_compile, do: args = args ++ ["--no-compile"]
+    args = case no_compile do
+      true -> args ++ ["--no-compile"]
+      _    -> args
+    end
     Mix.Task.run("app.start", args)
   end
 

--- a/lib/mix/tasks/bench_cmp.ex
+++ b/lib/mix/tasks/bench_cmp.ex
@@ -108,8 +108,9 @@ defmodule Mix.Tasks.Bench.Cmp do
       spacing = 3
       :io.format('~*.s ', [-max_name_len-spacing, name])
       color = choose_color(diff, format)
-      if format == :percent do
-        diff = Snapshot.format_percent(diff)
+      diff = case format do
+        :percent -> Snapshot.format_percent(diff)
+        _        -> diff
       end
       colordiff = IO.ANSI.format color ++ ["#{diff}"]
       IO.puts colordiff


### PR DESCRIPTION
Fixes these warnings:

```elixir
Compiling 9 files (.ex)
warning: the variable "args" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/mix/tasks/bench.ex:89

warning: the variable "diff" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/mix/tasks/bench_cmp.ex:114

```