### PR TITLE
Show header so it is easier to see what is what

### DIFF
--- a/lib/benchfella/snapshot/formatter.ex
+++ b/lib/benchfella/snapshot/formatter.ex
@@ -13,11 +13,20 @@ defmodule Benchfella.Snapshot.Formatter do
   end
 
   defp format_group({group_name, tests}, acc, max_len, :plain) do
-    [acc, ["## ", group_name, ?\n]] ++ format_entries(tests, max_len)
+    [acc, ["## ", group_name, ?\n]] ++
+    [format_header(max_len)] ++
+     format_entries(tests, max_len)
   end
 
   defp format_group({group_name, tests}, acc, max_len, :markdown) do
-    [[acc, ["* ", group_name, ?\n, ?\n, '```\n']] ++ format_entries(tests, max_len) | '```\n']
+    [[acc, ["* ", group_name, ?\n, ?\n, '```\n']] ++
+    [format_header(max_len)] ++
+    format_entries(tests, max_len) | '```\n']
+  end
+
+  defp format_header(max_len) do
+    '~*.s ~10s   ~s ~n'
+    |> :io_lib.format([-max_len - 1, "benchmark name", "iterations", "average time"])
   end
 
   defp format_entries(tests, max_len) do


### PR DESCRIPTION
It is relatively clear but I think it's better to name the columns, I was a bit confused about the number of iterations as they seemed to smooth and therefore wrong to me :)

Now looks like:

```
## MyMapBench
benchmark name          iterations   average time 
map with TCO reverse         50000   38.78 µs/op
map simple without TCO       50000   38.89 µs/op
map with TCO and ++            500   3142.94 µs/op
```