### PR TITLE
Allow custom command line options to benchmarks

### DIFF
--- a/lib/mix/tasks/bench.ex
+++ b/lib/mix/tasks/bench.ex
@@ -72,13 +72,8 @@ defmodule Mix.Tasks.Bench do
             d: :duration, o: :output]
 
   defp parse_options(args) do
-    case OptionParser.parse(args, strict: @switches, aliases: @aliases) do
-      {opts, paths, []} -> {paths, opts}
-      {_, _, [{opt, nil} | _]} ->
-        Mix.raise "Invalid option: #{opt}"
-      {_, _, [{opt, val} | _]} ->
-        Mix.raise "Invalid option: #{opt}=#{val}"
-    end
+    {opts, paths, _} = OptionParser.parse(args, strict: @switches, aliases: @aliases)
+    {paths, opts}
   end
 
   defp prepare_mix_project(no_compile) do


### PR DESCRIPTION
I have a single benchmark file I wish to run in various ways.

I want to tweak the environment based on some flags, but I don't want to copy/paste the benchmark file and change the value, instead I've defined an `OptionParser` to read system args to set the flags.

Sadly if I do `mix bench` is just exits if I try to use an unrecognised flag. It would be better to avoid stopping the benchmark.

For example, maybe I'm testing a library which can have a pool of N workers and I want to do:

```
$ mix bench --workers 10
$ mix bench --workers 25
```

This would let me see how much the pool size affects my throughput.

Any chance we can see this merged? It shouldn't cause many issues (nobody should be relying on an error being raised in command lines).