### PR TITLE
Fix Elixir 1.4 warning for Float.to_string/2

### DIFF
--- a/lib/benchfella/snapshot.ex
+++ b/lib/benchfella/snapshot.ex
@@ -85,7 +85,7 @@ defmodule Benchfella.Snapshot do
 
   def format_percent(num) do
     str = if num > 0 do <<?+>> else <<>> end
-    str <> Float.to_string(num, decimals: @precision) <> "%"
+    str <> :erlang.float_to_binary(num, decimals: @precision) <> "%"
   end
 
   defp diff(r1, r2, :ratio), do: Float.round(r2 / r1, @precision)


### PR DESCRIPTION
Fixes this warning:

warning: Float.to_string/2 is deprecated, use :erlang.float_to_binary/2
instead
  (elixir) lib/float.ex:414: Float.to_string/2
    lib/benchfella/snapshot.ex:88: Benchfella.Snapshot.format_percent/1
      lib/mix/tasks/bench_cmp.ex:112: anonymous fn/3 in
      Mix.Tasks.Bench.Cmp.print_diffs/3
        (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
          (elixir) lib/enum.ex:645: Enum.each/2