### PR TITLE
Enable executing mix bench from an umbrella root

### DIFF
--- a/lib/mix/tasks/bench.ex
+++ b/lib/mix/tasks/bench.ex
@@ -93,7 +93,8 @@ defmodule Mix.Tasks.Bench do
   end
 
   defp load_bench_files([]) do
-    Path.wildcard("bench/**/*_bench.exs")
+    Path.wildcard("bench/**/*_bench.exs") ++
+      Path.wildcard("apps/**/bench/**/*_bench.exs")
     |> do_load_bench_files
   end
 


### PR DESCRIPTION
This patch addresses #50 and allows you to run `mix bench` from an umbrella root