### PR TITLE
Convert :random to :rand to prevent warnings

### DIFF
--- a/bench/ets_bench.exs
+++ b/bench/ets_bench.exs
@@ -13,7 +13,7 @@ defmodule ETSBench do
 
   bench "ets insert", [unused: inspect_table(bench_context)] do
     tid = bench_context
-    :ets.insert(tid, {:random.uniform(1000), :x})
+    :ets.insert(tid, {:rand.uniform(1000), :x})
     :ok
   end
 


### PR DESCRIPTION
:random has been deprecated so it throws a warning when I use benchfella in my project. This converts to the now correct :rand