### PR TITLE
Remove warnings about missing EEx

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,10 @@ defmodule Benchfella.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [
+      applications: [],
+      extra_applications: [:eex]
+    ]
   end
 
   defp package do
@@ -37,7 +40,7 @@ defmodule Benchfella.Mixfile do
 
   defp docs do
     [
-      extras: [{:"LICENSE", [title: "License"]}, "README.md"],
+      extras: [{:LICENSE, [title: "License"]}, "README.md"],
       main: "readme",
       source_url: @source_url,
       assets: "assets",


### PR DESCRIPTION
This should us rid of

```
==> benchfella
Compiling 9 files (.ex)
warning: EEx.compile_file/2 defined in application :eex is used by the current application but the current application does not depend on :eex. To fix this, you must do one of:

  1. If :eex is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :eex is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :eex, you may optionally skip this warning by adding [xref: [exclude: [EEx]]] to your "def project" in mix.exs

  lib/mix/tasks/bench_graph.ex:93: Mix.Tasks.Bench.Graph
```